### PR TITLE
Fix typo in config.h.in.

### DIFF
--- a/libstdc++-v3/config.h.in
+++ b/libstdc++-v3/config.h.in
@@ -454,7 +454,7 @@
 /* Define if S_IFREG is available in <sys/stat.h>. */
 #undef HAVE_S_IFREG
 
-/* Define if S_IFREG is available in <sys/stat.h>. */
+/* Define if S_ISREG is available in <sys/stat.h>. */
 #undef HAVE_S_ISREG
 
 /* Define to 1 if you have the `tanf' function. */


### PR DESCRIPTION
I have noticed (when trying to manually compile libstdc++fs manually for cygwin) that there was an typo on config.h.in that would transfer over to config.h. So this PR fixes it.