### PR TITLE
configure doesn't work

### DIFF
--- a/libiberty/configure
+++ b/libiberty/configure
@@ -1879,7 +1879,7 @@ $4
 int
 main ()
 {
-if (sizeof (($2)))
+if (sizeof ($2))
 	    return 0;
   ;
   return 0;


### PR DESCRIPTION
configure causes the following problem.

checking size of long long... configure: error: in `/work/gcc-7.2.0/host-x86_64-pc-linux-gnu/libiberty':
configure: error: cannot compute sizeof (long long)
See `config.log' for more details.