### PR TITLE
Improve format of dump-parse-tree.c to comply with BNF machine readable criteria

### DIFF
--- a/gcc/fortran/parse.c
+++ b/gcc/fortran/parse.c
@@ -6097,6 +6097,25 @@ translate_all_program_units (gfc_namespace *gfc_global_ns_list)
   clean_up_modules (gfc_gsym_root);
 }
 
+static void dpt(gfc_namespace *gfc_current_ns)
+{
+  FILE *out;
+  const char *proc = gfc_current_ns->proc_name->name;
+  char *dptstr = (char *)xmalloc(strlen(global_options.x_dump_base_name)+strlen(proc)+10);
+  strcpy(dptstr, global_options.x_dump_base_name);
+  strcat(dptstr, "_");
+  strcat(dptstr, proc);
+  strcat(dptstr, ".dpt");
+  out = fopen(dptstr, "w");
+  if (out)
+    {
+      gfc_dump_parse_tree (gfc_current_ns, out);
+      fputs ("------------------------------------------\n\n", out);
+      fclose(out);
+    }
+  else
+    perror(dptstr);
+}
 
 /* Top level parser.  */
 
@@ -6215,8 +6234,7 @@ loop:
   gfc_resolve (gfc_current_ns);
 
   /* Dump the parse tree if requested.  */
-  if (flag_dump_fortran_original)
-    gfc_dump_parse_tree (gfc_current_ns, stdout);
+  if (flag_dump_fortran_original) dpt(gfc_current_ns);
 
   gfc_get_errors (NULL, &errors);
   if (s.state == COMP_MODULE || s.state == COMP_SUBMODULE)
@@ -6266,10 +6284,9 @@ done:
     if (!gfc_current_ns->proc_name
 	|| gfc_current_ns->proc_name->attr.flavor != FL_MODULE)
       {
-	gfc_dump_parse_tree (gfc_current_ns, stdout);
-	fputs ("------------------------------------------\n\n", stdout);
+      dpt(gfc_current_ns);
       }
-
+  
   /* Do the translation.  */
   translate_all_program_units (gfc_global_ns_list);
 


### PR DESCRIPTION
The file dump-parse-tree.c in gfortran is intended for use in debugging and documenting the gfc_code and gfc_expr data structures generated by the gfortran front-end. However it does not do so in an unambiguous manner because indenting is inconsistent, blank common is missing, format statements contain missing information, and keywords can be mistaken for identifiers and sundry problems such as '-' in keywords. This patch is intended to address those problems and dump the structures to the standard where it may be machine read and used as the basis of a tool for modernization of Fortran code or conversion between language source codes.

Testing:
The patch has no influence on the core of gcc. It only affects the Fortran front end when -fdump-parse-tree is specified. The output format may be tested using the package:
https://github.com/jrrk/dpt-parser.git

This patch was applied to the gcc-7-branch. The trunk was not building correctly at the time this patch was prepared.