### PR TITLE
Avoid redundant index check in __visit_invoke

### DIFF
--- a/libstdc++-v3/include/std/variant
+++ b/libstdc++-v3/include/std/variant
@@ -835,7 +835,7 @@ namespace __variant
       static constexpr __visit_invoke(_Visitor&& __visitor, _Variants... __vars)
       {
 	return __invoke(std::forward<_Visitor>(__visitor),
-			std::get<__indices>(
+			__get<__indices>(
 			    std::forward<_Variants>(__vars))...);
       }
 


### PR DESCRIPTION
__visit_invoke can call __get directly, since the fact it was called means each variant has the correct index.