### PR TITLE
WIP: x86_64 rtems - Improve support for building shared dynamic libraries

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -1509,7 +1509,7 @@ x86_64-*-elf*)
 	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h"
 	;;
 x86_64-*-rtems*)
-	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h i386/rtemself.h rtems.h"
+	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h i386/rtemself64.h rtems.h"
 	;;
 i[34567]86-*-rdos*)
     tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h i386/rdos.h"

--- a/gcc/config/arm/rtems.h
+++ b/gcc/config/arm/rtems.h
@@ -34,3 +34,7 @@
     } while (0)
 
 #define ARM_DEFAULT_SHORT_ENUMS false
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/bfin/rtems.h
+++ b/gcc/config/bfin/rtems.h
@@ -31,3 +31,7 @@
       builtin_assert ("system=rtems");		\
     }						\
   while (0)
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/i386/rtemself.h
+++ b/gcc/config/i386/rtemself.h
@@ -33,3 +33,7 @@
 	builtin_assert ("system=rtems");	\
     }						\
   while (0)
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crtbegin.o%s}"

--- a/gcc/config/i386/rtemself64.h
+++ b/gcc/config/i386/rtemself64.h
@@ -1,5 +1,6 @@
-/* Definitions for rtems targeting a v850 using ELF.
-   Copyright (C) 2012-2018 Free Software Foundation, Inc.
+/* Definitions for rtems targeting an x86_64 using ELF.
+   Copyright (C) 1996-2018 Free Software Foundation, Inc.
+   Contributed by Joel Sherrill (joel@OARcorp.com).
 
    This file is part of GCC.
 
@@ -27,18 +28,11 @@
 #define TARGET_OS_CPP_BUILTINS()		\
   do						\
     {						\
-      builtin_define( "__rtems__" );		\
-      builtin_assert( "system=rtems" );		\
+	builtin_define ("__rtems__");		\
+	builtin_define ("__USE_INIT_FINI__");	\
+	builtin_assert ("system=rtems");	\
     }						\
   while (0)
-
-/* Map mv850e1 and mv850es to mv850e to match MULTILIB_MATCHES */
-#undef  ASM_SPEC
-#define ASM_SPEC "%{mv850es:-mv850e} \
-%{mv850e1:-mv850e} \
-%{!mv850es:%{!mv850e1:%{mv*:-mv%*}} \
-%{m8byte-align:-m8byte-align} \
-%{mgcc-abi:-mgcc-abi}}"
 
 #undef STARTFILE_SPEC
 #define STARTFILE_SPEC "\

--- a/gcc/config/i386/rtemself64.h
+++ b/gcc/config/i386/rtemself64.h
@@ -34,6 +34,10 @@
     }						\
   while (0)
 
+#undef LINK_SPEC
+#define LINK_SPEC \
+  "%{shared:-shared}"
+
 #undef STARTFILE_SPEC
 #define STARTFILE_SPEC "\
 %{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s \

--- a/gcc/config/i386/rtemself64.h
+++ b/gcc/config/i386/rtemself64.h
@@ -36,4 +36,9 @@
 
 #undef STARTFILE_SPEC
 #define STARTFILE_SPEC "\
-%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s \
+  %{!shared:crtbegin.o%s} %{shared:crtbeginS.o%s}}"
+
+#undef ENDFILE_SPEC
+#define ENDFILE_SPEC \
+  "%{!shared:crtend.o%s} %{shared:crtendS.o%s} crtn.o%s"

--- a/gcc/config/i386/rtemself64.h
+++ b/gcc/config/i386/rtemself64.h
@@ -42,3 +42,8 @@
 #undef ENDFILE_SPEC
 #define ENDFILE_SPEC \
   "%{!shared:crtend.o%s} %{shared:crtendS.o%s} crtn.o%s"
+
+/* Use -fPIC by default unless specified otherwise */
+#undef CC1_SPEC
+#define CC1_SPEC \
+  "%{!fno-pic:%{!fno-PIC:%{!fpic:%{!fPIC: -fPIC}}}}"

--- a/gcc/config/m68k/rtemself.h
+++ b/gcc/config/m68k/rtemself.h
@@ -36,3 +36,7 @@
 	builtin_assert ("system=rtems");	\
     }						\
   while (0)
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/microblaze/rtems.h
+++ b/gcc/config/microblaze/rtems.h
@@ -35,3 +35,7 @@
   %{mbig-endian:-EB --oformat=elf32-microblaze} \
   %{mlittle-endian:-EL --oformat=elf32-microblazeel} \
   %{mxl-gp-opt:%{G*}} %{!mxl-gp-opt: -G 0}"
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/mips/rtems.h
+++ b/gcc/config/mips/rtems.h
@@ -37,3 +37,7 @@ do {					\
  */
 #undef MIPS_DEFAULT_GVALUE
 #define MIPS_DEFAULT_GVALUE 0
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/moxie/rtems.h
+++ b/gcc/config/moxie/rtems.h
@@ -38,3 +38,7 @@
 #undef PTRDIFF_TYPE
 #undef WCHAR_TYPE
 #undef WCHAR_TYPE_SIZE
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/nios2/rtems.h
+++ b/gcc/config/nios2/rtems.h
@@ -37,3 +37,7 @@ do {                                    \
 
    This is done so RTEMS targets have Thread Local Storage like Linux.  */
 #define TARGET_LINUX_ABI 1
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/riscv/rtems.h
+++ b/gcc/config/riscv/rtems.h
@@ -29,3 +29,7 @@
 	builtin_define ("__USE_INIT_FINI__");	\
 	builtin_assert ("system=rtems");	\
     } while (0)
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/rs6000/rtems.h
+++ b/gcc/config/rs6000/rtems.h
@@ -72,6 +72,11 @@
     }							\
   while (0)
 
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} ecrti.o%s crtbegin.o%s}"
+
 /* Copy and paste from linux64.h and freebsd64.h */
 #undef RELOCATABLE_NEEDS_FIXUP
 #define RELOCATABLE_NEEDS_FIXUP \

--- a/gcc/config/rtems.h
+++ b/gcc/config/rtems.h
@@ -30,11 +30,15 @@
  * Dummy start/end specification to let linker work as
  * needed by autoconf scripts using this compiler.
  */
+#if 0
 #undef STARTFILE_SPEC
-#define STARTFILE_SPEC "crt0.o%s"
+#define STARTFILE_SPEC "%{!qrtems: crt0.o%s}"
+#endif
 
+#if 0
 #undef ENDFILE_SPEC
 #define ENDFILE_SPEC   ""
+#endif
 
 /*
  * Some targets do not set up LIB_SPECS, override it, here.

--- a/gcc/config/sh/rtems.h
+++ b/gcc/config/sh/rtems.h
@@ -29,3 +29,7 @@
   builtin_define( "__rtems__" );		\
   builtin_assert( "system=rtems" );		\
 } while (0)
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/sh/rtemself.h
+++ b/gcc/config/sh/rtemself.h
@@ -29,3 +29,7 @@
   builtin_define( "__rtems__" );		\
   builtin_assert( "system=rtems" );		\
 } while (0)
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/gcc/config/sparc/rtemself.h
+++ b/gcc/config/sparc/rtemself.h
@@ -38,3 +38,7 @@
 
 /* Use the default */
 #undef LINK_GCC_C_SEQUENCE_SPEC
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "\
+%{!nostdlib: %{!qrtems: crt0.o%s} crti.o%s crtbegin.o%s}"

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -613,7 +613,7 @@ x86_64-*-elf* | x86_64-*-rtems*)
 	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
 	case ${host} in
 	  x86_64-*-rtems*)
-	    extra_parts="$extra_parts crti.o crtn.o"
+	    extra_parts="$extra_parts crti.o crtn.o crtbeginS.o crtendS.o"
 	    ;;
 	esac
 	;;


### PR DESCRIPTION
Things done:
- Build crtbeginS and crtendS within GCC itself
- Update specs to use these shared variants when appropriate
- Pass -shared flag from GCC to linker
- Use -fPIC by default for all code unless otherwise specified (this will let us build Newlib in a way that is compatible to build a shared library out of too)