### PR TITLE
add missed "size[0]==2" into commented example

### DIFF
--- a/libstdc++-v3/include/bits/gslice.h
+++ b/libstdc++-v3/include/bits/gslice.h
@@ -56,7 +56,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
    *  to begin at an array element described by the previous dimension.  The
    *  size array and stride array must be the same size.
    *
-   *  For example, if you have offset==3, stride[0]==11, size[1]==3,
+   *  For example, if we have offset==3, size[0]==2, stride[0]==11, size[1]==3,
    *  stride[1]==3, then slice[0,0]==array[3], slice[0,1]==array[6],
    *  slice[0,2]==array[9], slice[1,0]==array[14], slice[1,1]==array[17],
    *  slice[1,2]==array[20].


### PR DESCRIPTION
```
// A proof: print array[] indices that correspond gslice(3, {2,3}, {11,3}):
#include <algorithm>
#include <iostream>
#include <numeric>
#include <ranges>
#include <valarray>

auto main() -> int {
    std::valarray<int> va(32);
    std::iota(std::begin(va), std::end(va), 0);

    std::gslice g(
        3,      // offset==3
        {2, 3}, // {sizes}: size[0]==2, size[1]==3
        {11, 3} // {strides}: stride[0]==11, stride[1]==3
    );

    std::valarray<int> va2 = va[g];

    // print array[] indices: 3 6 9 14 17 20
    std::ranges::for_each(va2, [](int x) {
        std::cout << "array[" << x << "], "; 
    });
}
```