### PR TITLE
Fixed constraints on operator<=>(optional<T>, U)

### DIFF
--- a/libstdc++-v3/include/std/optional
+++ b/libstdc++-v3/include/std/optional
@@ -1234,7 +1234,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
     { return !__rhs || __lhs >= *__rhs; }
 
 #ifdef __cpp_lib_three_way_comparison
-  template<typename _Tp, typename _Up>
+  template<typename _Tp, three_way_comparable_with<_Tp> _Up>
     constexpr compare_three_way_result_t<_Tp, _Up>
     operator<=>(const optional<_Tp>& __x, const _Up& __v)
     { return bool(__x) ? *__x <=> __v : strong_ordering::less; }


### PR DESCRIPTION
operator<=>(std::optional<_Tp>,_Up) was underconstrained. _Up needs to fulfill std::three_way_comparable<_Tp>. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98842 and http://eel.is/c++draft/optional#comp.with.t-25.