### PR TITLE
misleading #line directive error message fix

### DIFF
--- a/libcpp/directives.cc
+++ b/libcpp/directives.cc
@@ -990,7 +990,12 @@ do_line (cpp_reader *pfile)
 		       &new_lineno, &wrapped))
     {
       if (token->type == CPP_EOF)
-	cpp_error (pfile, CPP_DL_ERROR, "unexpected end of file after #line");
+        {
+          if (pfile->buffer->next_line < pfile->buffer->rlimit)
+            cpp_error (pfile, CPP_DL_ERROR, "missing #line directive arguments");
+          else
+            cpp_error (pfile, CPP_DL_ERROR, "unexpected end of file after #line");
+        }
       else
 	cpp_error (pfile, CPP_DL_ERROR,
 		   "\"%s\" after #line is not a positive integer",


### PR DESCRIPTION
All the reasons of commit are described in a bug report in bugzilla there https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105005 .

results of edge case testing with adequate console output after "gcc -E example.c -o example" command:
1)
```example.c
1 #line
2 #warning "some warning, not an EOF"
```
```console output
example.c:1:6: error: missing #line directive arguments
    1 | #line
      |      ^
example.c:2:2: warning: #warning "some warning, not an EOF" [-Wcpp]
    2 | #warning "some warning, not an EOF"
      |  ^~~~~~~
```

2)
```example.c
1 #line
2  
```
```console output
example.c:1:6: error: missing #line directive arguments
    1 | #line
      |      ^
```

3)
```example.c
1 #line
```
```console output
example.c:1:6: error: unexpected end of file after #line
    1 | #line
      |      ^
```