### PR TITLE
Fix misnamed argument in vsnprintf implementation

### DIFF
--- a/libgfortran/runtime/error.c
+++ b/libgfortran/runtime/error.c
@@ -138,7 +138,7 @@ estr_writev (const struct iovec *iov, int iovcnt)
 
 #ifndef HAVE_VSNPRINTF
 static int
-gf_vsnprintf (char *str, size_t size, const char *format, va_list ap)
+gf_vsnprintf (char *buffer, size_t size, const char *format, va_list ap)
 {
   int written;
 


### PR DESCRIPTION
`gf_vsnprintf()` (the implementation of `vsnprintf()` provided for the case `HAVE_VSNPRINTF` is false) has its first argument named `str`, but references it as `buffer` throughout the function body. This PR renames the argument from `str` to `buffer` to match the body.
(As an aside, if anybody could enlighten me which header I'd need to install on a Debian-based system so `HAVE_VSNPRINTF` becomes true, I'd be grateful. I'm trying to compile a piece of software with a build system that makes it hard to change the source files of its dependencies, hence my best bet is to avoid compiling this function.)