### PR TITLE
Fixing Error: invalid type argument of unary '*' (have 'int')

### DIFF
--- a/libstdc++-v3/include/bits/locale_facets_nonio.tcc
+++ b/libstdc++-v3/include/bits/locale_facets_nonio.tcc
@@ -1474,8 +1474,8 @@ _GLIBCXX_END_NAMESPACE_LDBL_OR_CXX11
       // calls.  So e.g. if __fmt is "%p %I:%M:%S", we can't handle it
       // properly, because we first handle the %p am/pm specifier and only
       // later the 12-hour format specifier.
-      if ((void*)(this->*(&time_get::do_get)) == (void*)(&time_get::do_get))
-	__use_state = true;
+      if ((void*)(this->*(&time_get::do_get)) == (&time_get::do_get))	
+        __use_state = true;
 #pragma GCC diagnostic pop
 #endif
       __time_get_state __state = __time_get_state();


### PR DESCRIPTION
Had an error compiling [tiny-cuda-nn](https://github.com/NVlabs/tiny-cuda-nn) using gcc 12.1
Used this answer on [stackoverflow](https://stackoverflow.com/a/42875646/2224647) for reference, recompiled and the build succeeded. 