### PR TITLE
Improve diagnostics for void conversions

### DIFF
--- a/gcc/cp/cxx-pretty-print.cc
+++ b/gcc/cp/cxx-pretty-print.cc
@@ -359,6 +359,13 @@ cxx_pretty_printer::constant (tree t)
       }
       break;
 
+    case VOID_CST:
+      /* c_pretty_printer spells it "(void)0", but C++ prefers "void()". */
+      pp_cxx_type_specifier_seq (this, void_type_node);
+      pp_cxx_left_paren (this);
+      pp_cxx_right_paren (this);
+      break;
+
     case INTEGER_CST:
       if (NULLPTR_TYPE_P (TREE_TYPE (t)))
 	{

--- a/gcc/cp/typeck.cc
+++ b/gcc/cp/typeck.cc
@@ -9818,22 +9818,22 @@ convert_for_assignment (tree type, tree rhs,
 	  switch (errtype)
 	    {
 	    case ICR_DEFAULT_ARGUMENT:
-	      inform_at (rhs_loc, "initializing %qT default argument", type);
+	      inform (rhs_loc, "initializing %qT default argument", type);
 	      break;
 	    case ICR_ARGPASS:
-	      inform_at (rhs_loc, "passing %qT argument", type);
+	      inform (rhs_loc, "passing %qT argument", type);
 	      break;
 	    case ICR_CONVERTING:
-	      inform_at (rhs_loc, "converting to %qT", type);
+	      inform (rhs_loc, "converting to %qT", type);
 	      break;
 	    case ICR_INIT:
-	      inform_at (rhs_loc, "initializing %qT object", type);
+	      inform (rhs_loc, "initializing %qT object", type);
 	      break;
 	    case ICR_RETURN:
-	      inform_at (rhs_loc, "returning %qT", type);
+	      inform (rhs_loc, "returning %qT", type);
 	      break;
 	    case ICR_ASSIGN:
-	      inform_at (rhs_loc, "assigning to %qT expression", type);
+	      inform (rhs_loc, "assigning to %qT expression", type);
 	      break;
 	    default:
 	      gcc_unreachable();

--- a/gcc/cp/typeck.cc
+++ b/gcc/cp/typeck.cc
@@ -9265,7 +9265,7 @@ cp_build_modify_expr (location_t loc, tree lhs, enum tree_code modifycode,
 	      if (modifycode == INIT_EXPR)
 		error_at (loc, "array used as initializer");
 	      else
-		error_at (loc, "cannot assignment");
+		error_at (loc, "invalid array assignment");
 	    }
 	  return error_mark_node;
 	}

--- a/gcc/cp/typeck.cc
+++ b/gcc/cp/typeck.cc
@@ -2343,7 +2343,7 @@ decay_conversion (tree exp,
   if (code == VOID_TYPE)
     {
       if (complain & tf_error)
-	error_at (loc, "void value not ignored as it ought to be");
+	error_at (loc, "invalid use of void expression");
       return error_mark_node;
     }
   if (invalid_nonstatic_memfn_p (loc, exp, complain))
@@ -9006,8 +9006,12 @@ cp_build_modify_expr (location_t loc, tree lhs, enum tree_code modifycode,
 	if (VOID_TYPE_P (TREE_TYPE (rhs)))
 	  {
 	    if (complain & tf_error)
-	      error_at (cp_expr_loc_or_loc (rhs, loc),
-			"void value not ignored as it ought to be");
+	      {
+		error_at (cp_expr_loc_or_loc (rhs, loc),
+			  "invalid use of void expression");
+		inform (cp_expr_loc_or_loc (lhs, loc),
+			"assigning to %qT expression", lhstype);
+	      }
 	    return error_mark_node;
 	  }
 
@@ -9809,7 +9813,32 @@ convert_for_assignment (tree type, tree rhs,
   if (coder == VOID_TYPE)
     {
       if (complain & tf_error)
-	error_at (rhs_loc, "void value not ignored as it ought to be");
+	{
+	  error_at (rhs_loc, "invalid use of void expression");
+	  switch (errtype)
+	    {
+	    case ICR_DEFAULT_ARGUMENT:
+	      inform_at (rhs_loc, "initializing %qT default argument", type);
+	      break;
+	    case ICR_ARGPASS:
+	      inform_at (rhs_loc, "passing %qT argument", type);
+	      break;
+	    case ICR_CONVERTING:
+	      inform_at (rhs_loc, "converting to %qT", type);
+	      break;
+	    case ICR_INIT:
+	      inform_at (rhs_loc, "initializing %qT object", type);
+	      break;
+	    case ICR_RETURN:
+	      inform_at (rhs_loc, "returning %qT", type);
+	      break;
+	    case ICR_ASSIGN:
+	      inform_at (rhs_loc, "assigning to %qT expression", type);
+	      break;
+	    default:
+	      gcc_unreachable();
+	    }
+	}
       return error_mark_node;
     }
 

--- a/gcc/cp/typeck.cc
+++ b/gcc/cp/typeck.cc
@@ -9006,12 +9006,9 @@ cp_build_modify_expr (location_t loc, tree lhs, enum tree_code modifycode,
 	if (VOID_TYPE_P (TREE_TYPE (rhs)))
 	  {
 	    if (complain & tf_error)
-	      {
-		error_at (cp_expr_loc_or_loc (rhs, loc),
-			  "invalid use of void expression");
-		inform (cp_expr_loc_or_loc (lhs, loc),
-			"assigning to %qT expression", lhstype);
-	      }
+	      error_at (cp_expr_loc_or_loc (rhs, loc),
+			"cannot convert %qE from %<void%> to %qT for "
+			"assignment", rhs, lhstype);
 	    return error_mark_node;
 	  }
 
@@ -9268,7 +9265,7 @@ cp_build_modify_expr (location_t loc, tree lhs, enum tree_code modifycode,
 	      if (modifycode == INIT_EXPR)
 		error_at (loc, "array used as initializer");
 	      else
-		error_at (loc, "invalid array assignment");
+		error_at (loc, "cannot assignment");
 	    }
 	  return error_mark_node;
 	}
@@ -9813,32 +9810,34 @@ convert_for_assignment (tree type, tree rhs,
   if (coder == VOID_TYPE)
     {
       if (complain & tf_error)
-	{
-	  error_at (rhs_loc, "invalid use of void expression");
-	  switch (errtype)
-	    {
-	    case ICR_DEFAULT_ARGUMENT:
-	      inform (rhs_loc, "initializing %qT default argument", type);
-	      break;
-	    case ICR_ARGPASS:
-	      inform (rhs_loc, "passing %qT argument", type);
-	      break;
-	    case ICR_CONVERTING:
-	      inform (rhs_loc, "converting to %qT", type);
-	      break;
-	    case ICR_INIT:
-	      inform (rhs_loc, "initializing %qT object", type);
-	      break;
-	    case ICR_RETURN:
-	      inform (rhs_loc, "returning %qT", type);
-	      break;
-	    case ICR_ASSIGN:
-	      inform (rhs_loc, "assigning to %qT expression", type);
-	      break;
-	    default:
-	      gcc_unreachable();
-	    }
-	}
+	switch (errtype)
+	  {
+	  case ICR_DEFAULT_ARGUMENT:
+	    error_at (rhs_loc, "cannot convert %<void%> to %qT "
+		      "in default argument", type);
+	    break;
+	  case ICR_ARGPASS:
+	    error_at (rhs_loc, "cannot convert %<void%> to %qT "
+		      "in argument passing", type);
+	    break;
+	  case ICR_CONVERTING:
+	    error_at (rhs_loc, "cannot convert %<void%> to %qT", type);
+	    break;
+	  case ICR_INIT:
+	    error_at (rhs_loc, "cannot convert %<void%> to %qT "
+		      "in initialization", type);
+	    break;
+	  case ICR_RETURN:
+	    error_at (rhs_loc, "cannot convert %<void%> to %qT "
+		      "in return", type);
+	    break;
+	  case ICR_ASSIGN:
+	    error_at (rhs_loc, "cannot convert %<void%> to %qT "
+		      "in assignment", type);
+	    break;
+	  default:
+	    gcc_unreachable();
+	  }
       return error_mark_node;
     }
 

--- a/gcc/testsuite/g++.dg/cpp0x/pr51216.C
+++ b/gcc/testsuite/g++.dg/cpp0x/pr51216.C
@@ -4,8 +4,8 @@
 
 void foo()
 {
-  int i = ({ if (1) ; });           // { dg-error "ignored" }
-  int j = ({ for (;;) ; });         // { dg-error "ignored" }
-  int k = ({ while (1) ; });        // { dg-error "ignored" }
-  int l = ({ do { } while (1); });  // { dg-error "ignored" }
+  int i = ({ if (1) ; });           // { dg-error "cannot convert" }
+  int j = ({ for (;;) ; });         // { dg-error "cannot convert" }
+  int k = ({ while (1) ; });        // { dg-error "cannot convert" }
+  int l = ({ do { } while (1); });  // { dg-error "cannot convert" }
 }

--- a/gcc/testsuite/g++.dg/cpp1y/constexpr-84192.C
+++ b/gcc/testsuite/g++.dg/cpp1y/constexpr-84192.C
@@ -20,7 +20,7 @@ f3 (int n)
 {
   bool b = false;
   for (int i = 0; i < n; i++)
-    b = ({ break; });	// { dg-error "void value not ignored as it ought to be" }
+    b = ({ break; });	// { dg-error "invalid use of void expression" }
   return b;
 }
 

--- a/gcc/testsuite/g++.dg/cpp1y/constexpr-84192.C
+++ b/gcc/testsuite/g++.dg/cpp1y/constexpr-84192.C
@@ -20,7 +20,7 @@ f3 (int n)
 {
   bool b = false;
   for (int i = 0; i < n; i++)
-    b = ({ break; });	// { dg-error "invalid use of void expression" }
+    b = ({ break; });	// { dg-error "cannot convert" }
   return b;
 }
 

--- a/gcc/testsuite/g++.dg/parse/cond3.C
+++ b/gcc/testsuite/g++.dg/parse/cond3.C
@@ -8,8 +8,8 @@ extern void baz ();
 void
 foo (int i)
 {
-  (i ? j : k) = ({ l++; (void) l; });	// { dg-error "void value not ignored" }
-  (i ? j : k) += ({ l++; (void) l; });	// { dg-error "void value not ignored" }
-  (i ? j : k) = baz ();			// { dg-error "void value not ignored" }
-  (i ? j : k) *= baz ();		// { dg-error "void value not ignored" }
+  (i ? j : k) = ({ l++; (void) l; });	// { dg-error "cannot convert" }
+  (i ? j : k) += ({ l++; (void) l; });	// { dg-error "cannot convert" }
+  (i ? j : k) = baz ();			// { dg-error "cannot convert" }
+  (i ? j : k) *= baz ();		// { dg-error "cannot convert" }
 }

--- a/gcc/testsuite/g++.dg/parse/crash64.C
+++ b/gcc/testsuite/g++.dg/parse/crash64.C
@@ -3,5 +3,5 @@
 
 void foo()
 {
-  int i = ({ L: ; });  // { dg-error "void value not ignored" }
+  int i = ({ L: ; });  // { dg-error "cannot convert" }
 }

--- a/gcc/testsuite/g++.dg/template/stmtexpr2.C
+++ b/gcc/testsuite/g++.dg/template/stmtexpr2.C
@@ -7,14 +7,14 @@ template<int>
 void
 foo()
 {
-  int i = ({ }); // { dg-error "void value not ignored" }
+  int i = ({ }); // { dg-error "cannot convert" }
 }
 
 template<int>
 void
 bar()
 {
-  int i = ({ ({}); }); // { dg-error "void value not ignored" }
+  int i = ({ ({}); }); // { dg-error "cannot convert" }
 }
 
 int


### PR DESCRIPTION
'void value not ignored as it ought to be' is a holdover from K&R C and is utterly incomprehensible to the modern C++ developer.  Switch to 'invalid use of void expression' / 'cannot convert (%qE from) %<void%> to ' (already in use in cp/call.cc etc.) and add context/expected type information where available.

gcc is inconsistent in tense between "cannot" / "could not"; using "cannot" where it looks more consistent.

Omit misleading range labels where loc is unknown, e.g. in `void() ? x : y` (o/w the caret points to `y`, implying that gcc thinks that `y` is void).

Pretty print the void_cst as `void()` instead of `(void)0`. This conforms to C++ e.g. in  [dcl.type.auto.deduct],  [temp.variadic].
