### PR TITLE
Have bits/allocator.h include bits/stl_iterator.h

### DIFF
--- a/libstdc++-v3/include/bits/allocator.h
+++ b/libstdc++-v3/include/bits/allocator.h
@@ -46,6 +46,9 @@
 #include <bits/c++allocator.h> // Define the base class to std::allocator.
 #include <bits/memoryfwd.h>
 #if __cplusplus >= 201103L
+#if __cpp_exceptions
+#include <bits/stl_iterator.h> // for __make_move_if_noexcept_iterator, used by shrink_to_fit
+#endif
 #include <type_traits>
 #endif
 


### PR DESCRIPTION
Fixes
```
error: call to function '__make_move_if_noexcept_iterator' that is neither visible in the template definition nor found by argument-dependent lookup
            _Tp(__make_move_if_noexcept_iterator(__c.begin()),
```