### PR TITLE
Feature/permitted void cast

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*.cc]
+indent_style = tab
+indent_size = 2
+tab_width = 8
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile*,ChangeLog*]
+indent_style = tab
+indent_size = 8
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/gcc/testsuite/g++.dg/cpp0x/constexpr-cast2.C
+++ b/gcc/testsuite/g++.dg/cpp0x/constexpr-cast2.C
@@ -5,12 +5,17 @@
 static int i;
 constexpr void *vp0 = nullptr;
 constexpr void *vpi = &i;
-constexpr int *p1 = (int *) vp0; // { dg-error "cast from .void\\*. is not allowed" }
-constexpr int *p2 = (int *) vpi; // { dg-error "cast from .void\\*. is not allowed" }
-constexpr int *p3 = static_cast<int *>(vp0); // { dg-error "cast from .void\\*. is not allowed" }
-constexpr int *p4 = static_cast<int *>(vpi); // { dg-error "cast from .void\\*. is not allowed" }
+constexpr int *p1 = (char *) vp0; // { dg-error "cast from .void\\*. is not allowed" }
+constexpr int *p2 = (char *) vpi; // { dg-error "cast from .void\\*. is not allowed" }
+constexpr int *p1_err = (int *) vp0;
+constexpr int *p2_err = (int *) vpi;
+constexpr int *p3 = static_cast<char *>(vp0); // { dg-error "cast from .void\\*. is not allowed" }
+constexpr int *p4 = static_cast<char *>(vpi); // { dg-error "cast from .void\\*. is not allowed" }
+constexpr int *p3_err = static_cast<int *>(vp0);
+constexpr int *p4_err = static_cast<int *>(vpi);
 constexpr void *p5 = vp0;
 constexpr void *p6 = vpi;
 
 constexpr int *pi = &i;
-constexpr bool b = ((int *)(void *) pi == pi); // { dg-error "cast from .void\\*. is not allowed" }
+constexpr bool b = ((int *)(void *) pi == pi);
+constexpr bool c = ((int *)(void *) pi == (char *)(void*)pi); // { dg-error "cast from .void\\*. is not allowed" }


### PR DESCRIPTION
This is an early proof of concept for the static cast from void* to T* when the pointed to type is infact T*.