### PR TITLE
fix on ReExec implementation for tsan under linux_arm environment

### DIFF
--- a/libsanitizer/sanitizer_common/sanitizer_linux_libcdep.cpp
+++ b/libsanitizer/sanitizer_common/sanitizer_linux_libcdep.cpp
@@ -969,8 +969,8 @@ void ReExec() {
   // rely on that will fail to load shared libraries. Query AT_EXECFN instead.
   pathname = reinterpret_cast<const char *>(getauxval(AT_EXECFN));
 #endif
-
-  uptr rv = internal_execve(pathname, GetArgv(), GetEnviron());
+  char **argv = GetArgv();
+  uptr rv = internal_execve(argv[0], argv, GetEnviron());
   int rverrno;
   CHECK_EQ(internal_iserror(rv, &rverrno), true);
   Printf("execve failed, errno %d\n", rverrno);


### PR DESCRIPTION
Currently under linux arm platform, if ASLR is enabled, executable that is compiled and linked with tsan options will be set a maximum stack size instead of unlimited, and get reexecuted (because of a aarch patch, see details  https://reviews.llvm.org/D18003) . And that will rename the process as exe. If multiple process run with tsan, then they will all be renamed as exe and the tsan reports are also named as exe.{pid}, which makes it hard to identify a specific process. So instead of executing the link to the executable("/proc/self/exe"), try to pass the original argv[0] to execve function. And this will make the process reexecuted with their original name.