### PR TITLE
Fix move assignment in shared_lock

### DIFF
--- a/libstdc++-v3/include/std/shared_mutex
+++ b/libstdc++-v3/include/std/shared_mutex
@@ -778,6 +778,8 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
       shared_lock&
       operator=(shared_lock&& __sl) noexcept
       {
+	if (_M_owns)
+		unlock();
 	shared_lock(std::move(__sl)).swap(*this);
 	return *this;
       }


### PR DESCRIPTION
Make the move assignment op of the shared_lock behave as it is supposed to. 

https://en.cppreference.com/w/cpp/thread/shared_lock/operator%3D

If the lock is owned it is supposed to unlock the lockable before the swap.