### PR TITLE
`1.5 * curcap` -> `curcap + curcap / 2` in fs_path.cc

### DIFF
--- a/libstdc++-v3/src/c++17/fs_path.cc
+++ b/libstdc++-v3/src/c++17/fs_path.cc
@@ -447,8 +447,8 @@ path::_List::reserve(int newcap, bool exact = false)
 
   if (curcap < newcap)
     {
-      if (!exact && newcap < int(1.5 * curcap))
-	newcap = 1.5 * curcap;
+      if (!exact && newcap < curcap + curcap / 2)
+	newcap = curcap + curcap / 2;
 
       void* p = ::operator new(sizeof(_Impl) + newcap * sizeof(value_type));
       std::unique_ptr<_Impl, _Impl_deleter> newptr(::new(p) _Impl{newcap});


### PR DESCRIPTION
This change has two ihmo positive implications:

 - The implicit conversion from double to int is avoided (Avoiding a warning).

 - No double is used at all, which could be significant in some scenarios.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
