### PR TITLE
Update dyn-string.h and  corrected spelling of NULL.

### DIFF
--- a/include/dyn-string.h
+++ b/include/dyn-string.h
@@ -30,10 +30,10 @@ typedef struct dyn_string
 {
   int allocated;	/* The amount of space allocated for the string.  */
   int length;		/* The actual length of the string.  */
-  char *s;		/* The string itself, NUL-terminated.  */
+  char *s;		/* The string itself, NULL-terminated.  */
 }* dyn_string_t;
 
-/* The length STR, in bytes, not including the terminating NUL.  */
+/* The length STR, in bytes, not including the terminating NULL.  */
 #define dyn_string_length(STR)                                          \
   ((STR)->length)
 


### PR DESCRIPTION
Spelling of NUL was corrected to NULL.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
