### PR TITLE
Fix: _Hashtable::_M_remove_bucket_begin: no need to assign update before begin node

### DIFF
--- a/libstdc++-v3/include/bits/hashtable.h
+++ b/libstdc++-v3/include/bits/hashtable.h
@@ -872,13 +872,10 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	if (!__next_n || __next_bkt != __bkt)
 	  {
 	    // Bucket is now empty
-	    // First update next bucket if any
+	    // Update next bucket if any
 	    if (__next_n)
 	      _M_buckets[__next_bkt] = _M_buckets[__bkt];
 
-	    // Second update before begin node if necessary
-	    if (&_M_before_begin == _M_buckets[__bkt])
-	      _M_before_begin._M_nxt = __next_n;
 	    _M_buckets[__bkt] = nullptr;
 	  }
       }


### PR DESCRIPTION
_Hashtable is used by unordered_map and unorderd_set.
This fix can imporve the performance of unordered_map::erase and unorderd_set::erase.

_M_remove_bucket_begin is called by _M_erase, when __prev_n is _M_buckets[__bkt].
And in _M_erase, the __prev_n->_M_nxt will always be assigned the next node of the last erased node.
So there is no need to determine whether _M_buckets[__bkt] is before begin node and update before begin node if necessary.

My Test Case1:
```c++
#include <cstdio>
#include <cstdint>
#include <unordered_set>

int main() {
  std::unordered_set<int> a;

  a.emplace(1);
  a.emplace(2);
  a.emplace(3);
  a.emplace(4);
  a.emplace(5);
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(2);
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(5);
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(3);
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(4);
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(1);
  for (auto i : a) printf("%d ", i); printf("\n");

  a.emplace(1);
  a.emplace(2);
  a.emplace(3);
  a.emplace(4);
  a.emplace(5);
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(++++a.begin());
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(a.begin());
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(++a.begin());
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(a.begin());
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(a.begin());
  for (auto i : a) printf("%d ", i); printf("\n");

  a.emplace(1);
  a.emplace(2);
  a.emplace(3);
  a.emplace(4);
  a.emplace(5);
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(a.begin(), ++++++a.begin());
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(a.begin());
  for (auto i : a) printf("%d ", i); printf("\n");
  a.erase(a.begin());
  for (auto i : a) printf("%d ", i); printf("\n");

  return 0;
}
```
The result after fix is the same with the result before. And the result is:
```
5 4 3 1 2 
5 4 3 1 
4 3 1 
4 1 
1 

5 4 3 2 1 
5 4 2 1 
4 2 1 
4 1 
1 

5 4 3 2 1 
2 1 
1 

```

My Test Case 2:
```c++
#include <cstdio>
#include <cstdint>
#include <unordered_set>

int main() {
  std::unordered_set<int> a;

  for (int i = 0; i < 1000000; ++i) {
    a.emplace(1);
    a.emplace(2);
    a.emplace(3);
    a.emplace(4);
    a.emplace(5);
    a.erase(2);
    a.erase(5);
    a.erase(3);
    a.erase(4);
    a.erase(1);

    a.emplace(1);
    a.emplace(2);
    a.emplace(3);
    a.emplace(4);
    a.emplace(5);
    a.erase(++++a.begin());
    a.erase(a.begin());
    a.erase(++a.begin());
    a.erase(a.begin());
    a.erase(a.begin());

    a.emplace(1);
    a.emplace(2);
    a.emplace(3);
    a.emplace(4);
    a.emplace(5);
    a.erase(a.begin(), ++++++a.begin());
    a.erase(a.begin());
    a.erase(a.begin());
  }

  return 0;
}
```
Run command: time ./a.out
before fix:
```
real    0m0.803s
user    0m0.803s
sys     0m0.000s
```
after fix:
```
real    0m0.778s
user    0m0.778s
sys     0m0.000s
```

Compile command: g++ -O2 --std=c++17 test.cc