### PR TITLE
Remove parameter of gcc: -V, -qversion

### DIFF
--- a/configure
+++ b/configure
@@ -5241,7 +5241,7 @@ fi
 $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++ compiler version" >&5
 set X $ac_compile
 ac_compiler=$2
-for ac_option in --version -v -V -qversion; do
+for ac_option in --version -v; do
   { { ac_try="$ac_compiler $ac_option >&5"
 case "(($ac_try" in
   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;


### PR DESCRIPTION
**Error log when compiling gcc with make:**

- gcc version 9.3.0 (Ubuntu 9.3.0-10ubuntu2) 
- configure:5203: $? = 0
- configure:5192: g++ -V >&5
- g++: error: unrecognized command line option '-V'
- g++: fatal error: no input files
- g++: fatal error: no input files
- configure:5203: $? = 1
- configure:5192: g++ -qversion >&5
- g++: error: unrecognized command line option '-qversion'; did you mean '--version'?
- g++: fatal error: no input files

**Compilation fails because gcc/g++ doesn't support “-V”, “-qversion” as arguments, compiles successfully after removing them in configure.**
