### PR TITLE
libstdc++: Remove duplicate using-declaration

### DIFF
--- a/libstdc++-v3/include/c_compatibility/wchar.h
+++ b/libstdc++-v3/include/c_compatibility/wchar.h
@@ -41,7 +41,6 @@ using std::btowc;
 using std::wctob;
 using std::fgetwc;
 using std::fgetws;
-using std::fgetws;
 using std::fputwc;
 using std::fputws;
 using std::fwide;

--- a/libstdc++-v3/include/c_compatibility/wchar.h
+++ b/libstdc++-v3/include/c_compatibility/wchar.h
@@ -40,7 +40,7 @@ using std::wint_t;
 using std::btowc;
 using std::wctob;
 using std::fgetwc;
-using std::fgetwc;
+using std::fgetws;
 using std::fgetws;
 using std::fputwc;
 using std::fputws;


### PR DESCRIPTION
> Thanks for taking the time to contribute to GCC! Please be advised that if you are
> viewing this on `github.com`, the mirror there is unofficial and unmonitored.

I know that, it is a small fix.

This part of the code exposes the C functions of wchar. It seems that the writer of the edited line forgot to change the last character after duplicating the line and the compiler doesn't complain about duplicate `using` declaration (or it does but it definitely compiles without errors). 


