### PR TITLE
Fix wrong macro name in FreeBSD config for RISCV

### DIFF
--- a/gcc/config/riscv/freebsd.h
+++ b/gcc/config/riscv/freebsd.h
@@ -42,7 +42,7 @@ along with GCC; see the file COPYING3.  If not see
 #define LINK_SPEC "						\
   -melf" XLEN_SPEC DEFAULT_ENDIAN_SPEC "riscv			\
   %{p:%nconsider using `-pg' instead of `-p' with gprof (1)}	\
-  " FBSD_LINK_PG_NOTES "						\
+  " FBSD_LINK_PG_NOTE "						\
   %{v:-V}							\
   %{assert*} %{R*} %{rpath*} %{defsym*}				\
   -X								\


### PR DESCRIPTION
The author of 48abb54 misspelled the macro name in the FreeBSD config file for RISCV. This unfortunately causes the compilation of GCC toolchains targeting `riscv64-unknown-freebsd14.*` to fail with the following error:

```
In file included from ./tm.h:44,
                 from ../../gcc/gcc.cc:35:
../../gcc/config/riscv/freebsd.h:45:5: error: expected ‘,’ or ‘;’ before ‘FBSD_LINK_PG_NOTES’
   45 |   " FBSD_LINK_PG_NOTES "                                                \
      |     ^~~~~~~~~~~~~~~~~~
../../gcc/gcc.cc:1211:32: note: in expansion of macro ‘LINK_SPEC’
 1211 | static const char *link_spec = LINK_SPEC;
      |                                ^~~~~~~~~
```