### PR TITLE
FEAT: one byte for "true" & "false"

### DIFF
--- a/gcc/ginclude/stdbool.h
+++ b/gcc/ginclude/stdbool.h
@@ -34,8 +34,8 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 /* bool, true and false are keywords.  */
 #else
 #define bool	_Bool
-#define true	1
-#define false	0
+#define true	((bool)1)
+#define false	((bool)0)
 #endif
 
 #else /* __cplusplus */


### PR DESCRIPTION
# In C language,

- the size of "true" and "false" macros is 4 byte and size of macro "bool" (typedef of _Bool) is 1 byte.

- By this simple change, we can set the size of "true" and "false" to 1 byte.

- This change will decrease the memory usage.