### PR TITLE
libstdc++: move libc++23convenience.la from experimental to libstdc++

### DIFF
--- a/libstdc++-v3/src/Makefile.am
+++ b/libstdc++-v3/src/Makefile.am
@@ -145,7 +145,8 @@ libstdc___la_LIBADD = \
 	$(top_builddir)/src/c++98/libc++98convenience.la \
 	$(top_builddir)/src/c++11/libc++11convenience.la \
 	$(top_builddir)/src/c++17/libc++17convenience.la \
-	$(top_builddir)/src/c++20/libc++20convenience.la
+	$(top_builddir)/src/c++20/libc++20convenience.la \
+	$(top_builddir)/src/c++23/libc++23convenience.la
 
 libstdc___la_DEPENDENCIES = \
 	${version_dep} \
@@ -153,7 +154,8 @@ libstdc___la_DEPENDENCIES = \
 	$(top_builddir)/src/c++98/libc++98convenience.la \
 	$(top_builddir)/src/c++11/libc++11convenience.la \
 	$(top_builddir)/src/c++17/libc++17convenience.la \
-	$(top_builddir)/src/c++20/libc++20convenience.la
+	$(top_builddir)/src/c++20/libc++20convenience.la \
+	$(top_builddir)/src/c++23/libc++23convenience.la
 
 if ENABLE_DARWIN_AT_RPATH
 libstdc___darwin_rpath = -Wc,-nodefaultrpaths

--- a/libstdc++-v3/src/Makefile.in
+++ b/libstdc++-v3/src/Makefile.in
@@ -552,7 +552,8 @@ libstdc___la_LIBADD = \
 	$(top_builddir)/src/c++98/libc++98convenience.la \
 	$(top_builddir)/src/c++11/libc++11convenience.la \
 	$(top_builddir)/src/c++17/libc++17convenience.la \
-	$(top_builddir)/src/c++20/libc++20convenience.la
+	$(top_builddir)/src/c++20/libc++20convenience.la \
+	$(top_builddir)/src/c++23/libc++23convenience.la
 
 libstdc___la_DEPENDENCIES = \
 	${version_dep} \
@@ -560,7 +561,8 @@ libstdc___la_DEPENDENCIES = \
 	$(top_builddir)/src/c++98/libc++98convenience.la \
 	$(top_builddir)/src/c++11/libc++11convenience.la \
 	$(top_builddir)/src/c++17/libc++17convenience.la \
-	$(top_builddir)/src/c++20/libc++20convenience.la
+	$(top_builddir)/src/c++20/libc++20convenience.la \
+	$(top_builddir)/src/c++23/libc++23convenience.la
 
 @ENABLE_DARWIN_AT_RPATH_TRUE@libstdc___darwin_rpath =  \
 @ENABLE_DARWIN_AT_RPATH_TRUE@	-Wc,-nodefaultrpaths \

--- a/libstdc++-v3/src/experimental/Makefile.am
+++ b/libstdc++-v3/src/experimental/Makefile.am
@@ -46,12 +46,10 @@ sources = \
 libstdc__exp_la_SOURCES = $(sources)
 
 libstdc__exp_la_LIBADD = \
-	$(top_builddir)/src/c++23/libc++23convenience.la \
 	$(top_builddir)/src/c++26/libc++26convenience.la \
 	$(filesystem_lib) $(backtrace_lib)
 
 libstdc__exp_la_DEPENDENCIES = \
-	$(top_builddir)/src/c++23/libc++23convenience.la \
 	$(top_builddir)/src/c++26/libc++26convenience.la \
 	$(filesystem_lib) $(backtrace_lib)
 

--- a/libstdc++-v3/src/experimental/Makefile.in
+++ b/libstdc++-v3/src/experimental/Makefile.in
@@ -461,12 +461,10 @@ sources = \
 # vpath % $(top_srcdir)/src/experimental
 libstdc__exp_la_SOURCES = $(sources)
 libstdc__exp_la_LIBADD = \
-	$(top_builddir)/src/c++23/libc++23convenience.la \
 	$(top_builddir)/src/c++26/libc++26convenience.la \
 	$(filesystem_lib) $(backtrace_lib)
 
 libstdc__exp_la_DEPENDENCIES = \
-	$(top_builddir)/src/c++23/libc++23convenience.la \
 	$(top_builddir)/src/c++26/libc++26convenience.la \
 	$(filesystem_lib) $(backtrace_lib)
 


### PR DESCRIPTION
`libc++23convenience.la` is still in the `experimental` section, not integrated into the main `libstdc++`,
which leads to the precompiled static library `libstdc++.a` not including the necessary C++23 features, 
specifically the `<print>` library.

For Windows MinGW-w64 builds, the following issues are observed:
Even if you specify `-std=c++23` flag, you cannot use `std::print()` and other functions due to missing linkage,
you need to link against the `libstdc++exp` library manually.

---

I'm not sure if the C++23 features were intentionally excluded from the `libstdc++.a` static library, or just forgotten.