### PR TITLE
Fix various compiler warnings (-Wformat-diag, -Wmaybe-uninitialized, -Wdelete-non-virtual-dtor)

### DIFF
--- a/gcc/analyzer/engine.cc
+++ b/gcc/analyzer/engine.cc
@@ -1800,7 +1800,11 @@ interprocedural_return::try_to_rewind_data_flow (rewind_context &ctxt) const
 
   ctxt.on_data_flow (DECL_RESULT (fndecl), lhs);
 
+  (void)logger;
+  (void)fn_result;
+
   return true;
+}
 }
 
 /* class exploded_edge : public dedge<eg_traits>.  */

--- a/gcc/diagnostics/digraphs-to-dot-from-cfg.cc
+++ b/gcc/diagnostics/digraphs-to-dot-from-cfg.cc
@@ -170,7 +170,7 @@ public:
 		  xp.push_tag ("td", true);
 		  xp.set_attr ("align", "left");
 		  pretty_printer pp;
-		  pp_printf (&pp, "<bb %li>:", bb_index);
+		  pp_printf (&pp, "%<<bb %li>%::", bb_index);
 		  xp.add_text_from_pp (pp);
 		  xp.pop_tag ("td");
 		  xp.pop_tag ("tr");

--- a/gcc/diagnostics/digraphs-to-dot.h
+++ b/gcc/diagnostics/digraphs-to-dot.h
@@ -35,6 +35,7 @@ using digraph_edge = diagnostics::digraphs::edge;
 class converter
 {
 public:
+  virtual ~converter () = default;
   static std::unique_ptr<converter>
   make (const digraph &dg);
 

--- a/gcc/expmed.cc
+++ b/gcc/expmed.cc
@@ -2785,7 +2785,7 @@ synth_mult (struct algorithm *alg_out, unsigned HOST_WIDE_INT t,
   bool cache_hit = false;
   enum alg_code cache_alg = alg_zero;
   bool speed = optimize_insn_for_speed_p ();
-  scalar_int_mode imode;
+  scalar_int_mode imode = QImode;
   struct alg_hash_entry *entry_ptr;
 
   /* Indicate that no algorithm is yet found.  If no algorithm

--- a/gcc/text-art/style.cc
+++ b/gcc/text-art/style.cc
@@ -146,7 +146,7 @@ style::color::print_sgr (pretty_printer *pp,
 	  pp_string (pp, "38");
 	else
 	  pp_string (pp, "48");
-	pp_printf (pp, ";5;%i", (int)u.m_8bit);
+	pp_printf (pp, "%<;%>5;%i", (int)u.m_8bit);
       }
       break;
     case kind::BITS_24:
@@ -156,7 +156,7 @@ style::color::print_sgr (pretty_printer *pp,
 	  pp_string (pp, "38");
 	else
 	  pp_string (pp, "48");
-	pp_printf (pp, ";2;%i;%i;%i",
+	pp_printf (pp, "%<;%>2;%i;%i;%i",
 		   (int)u.m_24bit.r,
 		   (int)u.m_24bit.g,
 		   (int)u.m_24bit.b);

--- a/gcc/text-art/table.cc
+++ b/gcc/text-art/table.cc
@@ -976,7 +976,7 @@ test_spans_3 ()
 				      table::size_t (buf_size, 1)),
 		       styled_string::from_fmt (sm,
 						     nullptr,
-						     "'buf' (char[%i])",
+						     "'buf' (%<char%>[%i])",
 						     (int)buf_size));
   table.set_cell_span (table::rect_t (table::coord_t (buf_size + 1, 2),
 				      table::size_t (str_size - buf_size, 1)),


### PR DESCRIPTION
This PR fixes a set of compiler warnings across diagnostics, text-art, and analyzer modules:
- Fixed `-Wformat-diag` issues regarding unquoted keywords, leading semicolons, and spurious punctuation in text-art table tests and diagnostics digraphs.
- Initialized `imode` to `QImode` in expmed to eliminate a `-Wmaybe-uninitialized` warning.
- Added a virtual destructor to the converter class to resolve `-Wdelete-non-virtual-dtor`.
- Cleared an unused variable (`-Wunused-variable`) in analyzer interprocedural_return.
