### PR TITLE
Fix typo in ylwrap comment

### DIFF
--- a/ylwrap
+++ b/ylwrap
@@ -1,5 +1,5 @@
 #! /bin/sh
-# ylwrap - wrapper for lex/yacc invocations.
+# ylwrap - wrapper for lex/yacc invocations..
 
 scriptversion=2013-01-12.17; # UTC
 


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
